### PR TITLE
Update Slack notifier for Skip Announcements

### DIFF
--- a/app_versions.json
+++ b/app_versions.json
@@ -13,5 +13,5 @@
   "cookbook_release_creator": "1.2.0",
   "cookbook_release_validator": "1.0.2",
   "cookbook_supermarket_uploader": "1.0.3",
-  "deployment_status_slack_notifier": "1.1.1"
+  "deployment_status_slack_notifier": "1.2.0"
 }

--- a/modules/deployment_status_slack_notifier/main.tf
+++ b/modules/deployment_status_slack_notifier/main.tf
@@ -35,6 +35,10 @@ resource "kubernetes_deployment" "deployment" {
             }
           }
           env {
+            name  = "SKIP_LABEL"
+            value = "Skip: Announcements"
+          }
+          env {
             name  = "SUCCESS_WEBHOOKS"
             value = var.success_webhooks
           }


### PR DESCRIPTION
## Description

Enables the slack notifier to skip announcements channel based on label
https://github.com/sous-chefs/repo-management/pull/55 adds label;

Signed-off-by: Jason Field <jason@avon-lea.co.uk>


### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
